### PR TITLE
Use _instances.length instead of count in _render function

### DIFF
--- a/dom-repeat-n.html
+++ b/dom-repeat-n.html
@@ -157,7 +157,7 @@ Example:
     },
 
     _render: function() {
-      for (var i=0; i<this.count; i++) {
+      for (var i=0, k=this._instances.length; i<k; i++) {
         var inst = this._instances[i];
         inst.__setProperty(this.indexAs, i*this.increment+this.start, true);
       }


### PR DESCRIPTION
Uses `this._instances.length` instead of `count` in the `_render` function. Resolves #4